### PR TITLE
Fixes format() used on print() instead of string

### DIFF
--- a/utils/evaluate_template.py
+++ b/utils/evaluate_template.py
@@ -89,7 +89,7 @@ def process_template(palette, inpath, outpath=None):
     def repl(matcher):
         return matcher.group('format').format(**palette)
 
-    print("\nProcessing {}...").format(inpath)
+    print("\nProcessing {}...".format(inpath))
     with open(inpath, 'r') as ifile, open(outpath, 'w') as ofile :
         for line in ifile.readlines():
             try:
@@ -97,7 +97,7 @@ def process_template(palette, inpath, outpath=None):
             except TypeError:
                 print("ERROR: attribute not available in palette")
                 sys.exit(1)
-    print("Result written to {}").format(outpath)
+    print("Result written to {}".format(outpath))
 
 
 def process_directory_recursively(palette, directory):


### PR DESCRIPTION
In `evaluate_template.py` `format()` was used on the `print()` function instead of the string inside it resulting in errors like

``` terminal
Processing {}...                                                                                               
Traceback (most recent call last):                                                                             
  File "evaluate_template.py", line 137, in <module>                                                           
    process_template(palette, path)                                                                            
  File "evaluate_template.py", line 109, in process_template                                                   
    print("\nProcessing {}...").format(inpath)                                                                 
AttributeError: 'NoneType' object has no attribute 'format'
```

You can find the same issue [here](https://github.com/jan-warchol/selenized/commit/3bbdd5058636aec420c3f8bce92129616c7472d7#diff-526692224eaa7829d0078e0eee47fb47R152) although I am not sure how to proceed with that script. [On line 144](https://github.com/jan-warchol/selenized/blob/7fd401dd648aa362acf5b7c295da53cb5f8e3367/utils/convert_color.py#L144) `selenized_medium` is being imported. Since this has moved to `utils/palettes/archive` I would propose to remove this default fallback.

``` diff
diff --git a/utils/convert_color.py b/utils/convert_color.py
index 15962ec..802c089 100755
--- a/utils/convert_color.py
+++ b/utils/convert_color.py
@@ -44,7 +44,7 @@ def parse_string(s):
     hex_num = r'([0-9a-fA-F]{2})'
     dec_num = r'(-?[0-9]{1,3})'
     hex_color_re = re.compile(r'#?' + hex_num*3)
-    dec_color_re = re.compile(',?\s*'.join([dec_num]*3))
+    dec_color_re = re.compile(r',?\s*'.join([dec_num]*3))
 
     coords = hex_color_re.match(s)
     if coords:
@@ -120,34 +120,21 @@ class Color(object):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 2:
+    if len(sys.argv) != 2:
         print(USAGE)
         sys.exit()
 
-    if len(sys.argv) == 2:
-        arg = sys.argv[1]
-        try:
-            with open(arg) as f:
-                colors = [Color(l) for l in f.read().rstrip().split('\n') if len(l)]
-        except IOError:
-            colors = [Color(arg)]
-
-        header = (
-            "CIE L*a*b*    HSV           sRGB      AppleRGB\n"
-            "-----------   -----------   -------   --------"
-        )
-        print('\n', header)
-        for c in colors:
-            print(c)
-
-    else:
-        import selenized_medium
-        palette = {
-            name: Color(color)
-            for name, color
-            in selenized_medium.palette.items()
-        }
-
-        for name, color in palette.items():
-            print("{:<12}{}").format(name, color)
+    arg = sys.argv[1]
+    try:
+        with open(arg) as f:
+            colors = [Color(l) for l in f.read().rstrip().split('\n') if len(l)]
+    except IOError:
+        colors = [Color(arg)]
 
+    header = (
+        "CIE L*a*b*    HSV           sRGB      AppleRGB\n"
+        "-----------   -----------   -------   --------"
+    )
+    print('\n', header)
+    for c in colors:
+        print(c)
```

What do you think?