### PR TITLE
Add Termite color scheme

### DIFF
--- a/termite/README.md
+++ b/termite/README.md
@@ -1,0 +1,5 @@
+ Color schemes for the [Termite](https://github.com/thestinger/termite) terminal
+
+ Paste the `[colors]` section into your config, for example see [config](https://github.com/thestinger/termite/blob/master/config) and `man termite.conf`.
+
+

--- a/termite/selenized-black.config
+++ b/termite/selenized-black.config
@@ -1,0 +1,32 @@
+[colors]
+# Selenized black colorscheme for Termite
+
+# 20% background transparency (requires a compositor)
+#background = rgba(63, 63, 63, 0.8)
+
+foreground = #b9b9b9
+foreground_bold = #dedede
+#foreground_dim = #888888
+background = #181818
+cursor = #b9b9b9
+
+# if unset, will reverse foreground and background
+#highlight = #839496
+
+# colors from color0 to color254 can be set
+color0 = #252525
+color1 = #ed4a46
+color2 = #70b433
+color3 = #dbb32d
+color4 = #368aeb
+color5 = #eb6eb7
+color6 = #3fc5b7
+color7 = #777777
+color8 = #3b3b3b
+color9 = #ff5e56
+color10 = #83c746
+color11 = #efc541
+color12 = #4f9cfe
+color13 = #ff81ca
+color14 = #56d8c9
+color15 = #dedede

--- a/termite/selenized-black.config
+++ b/termite/selenized-black.config
@@ -11,7 +11,7 @@ background = #181818
 cursor = #b9b9b9
 
 # if unset, will reverse foreground and background
-#highlight = #839496
+highlight = #3b3b3b
 
 # colors from color0 to color254 can be set
 color0 = #252525

--- a/termite/selenized-dark.config
+++ b/termite/selenized-dark.config
@@ -1,0 +1,32 @@
+[colors]
+# Selenized dark colorscheme for Termite
+
+# 20% background transparency (requires a compositor)
+#background = rgba(63, 63, 63, 0.8)
+
+foreground = #adbcbc
+foreground_bold = #cad8d9
+#foreground_dim = #888888
+background = #103c48
+cursor = #adbcbc
+
+# if unset, will reverse foreground and background
+#highlight = #839496
+
+# colors from color0 to color254 can be set
+color0 = #184956
+color1 = #fa5750
+color2 = #75b938
+color3 = #dbb32d
+color4 = #4695f7
+color5 = #f275be
+color6 = #41c7b9
+color7 = #72898f
+color8 = #2d5b69
+color9 = #ff665c
+color10 = #84c747
+color11 = #ebc13d
+color12 = #58a3ff
+color13 = #ff84cd
+color14 = #53d6c7
+color15 = #cad8d9

--- a/termite/selenized-dark.config
+++ b/termite/selenized-dark.config
@@ -11,7 +11,7 @@ background = #103c48
 cursor = #adbcbc
 
 # if unset, will reverse foreground and background
-#highlight = #839496
+highlight = #2d5b69
 
 # colors from color0 to color254 can be set
 color0 = #184956

--- a/termite/selenized-light.config
+++ b/termite/selenized-light.config
@@ -1,0 +1,32 @@
+[colors]
+# Selenized light colorscheme for Termite
+
+# 20% background transparency (requires a compositor)
+#background = rgba(63, 63, 63, 0.8)
+
+foreground = #53676d
+foreground_bold = #3a4d53
+#foreground_dim = #888888
+background = #fbf3db
+cursor = #53676d
+
+# if unset, will reverse foreground and background
+#highlight = #839496
+
+# colors from color0 to color254 can be set
+color0 = #ece3cc
+color1 = #d2212d
+color2 = #489100
+color3 = #ad8900
+color4 = #0072d4
+color5 = #ca4898
+color6 = #009c8f
+color7 = #909995
+color8 = #d5cdb6
+color9 = #cc1729
+color10 = #428b00
+color11 = #a78300
+color12 = #006dce
+color13 = #c44392
+color14 = #00978a
+color15 = #3a4d53

--- a/termite/selenized-light.config
+++ b/termite/selenized-light.config
@@ -11,7 +11,7 @@ background = #fbf3db
 cursor = #53676d
 
 # if unset, will reverse foreground and background
-#highlight = #839496
+highlight = #d5cdb6
 
 # colors from color0 to color254 can be set
 color0 = #ece3cc

--- a/termite/selenized-white.config
+++ b/termite/selenized-white.config
@@ -1,0 +1,32 @@
+[colors]
+# Selenized white colorscheme for Termite
+
+# 20% background transparency (requires a compositor)
+#background = rgba(63, 63, 63, 0.8)
+
+foreground = #474747
+foreground_bold = #282828
+#foreground_dim = #888888
+background = #ffffff
+cursor = #474747
+
+# if unset, will reverse foreground and background
+#highlight = #839496
+
+# colors from color0 to color254 can be set
+color0 = #ebebeb
+color1 = #d6000c
+color2 = #1d9700
+color3 = #c49700
+color4 = #0064e4
+color5 = #dd0f9d
+color6 = #00ad9c
+color7 = #878787
+color8 = #cdcdcd
+color9 = #bf0000
+color10 = #008400
+color11 = #af8500
+color12 = #0054cf
+color13 = #c7008b
+color14 = #009a8a
+color15 = #282828

--- a/termite/selenized-white.config
+++ b/termite/selenized-white.config
@@ -11,7 +11,7 @@ background = #ffffff
 cursor = #474747
 
 # if unset, will reverse foreground and background
-#highlight = #839496
+highlight = #cdcdcd
 
 # colors from color0 to color254 can be set
 color0 = #ebebeb

--- a/utils/templates/termite.config.template
+++ b/utils/templates/termite.config.template
@@ -11,7 +11,7 @@ background = !!COL!{bg.srgb}!
 cursor = !!COL!{fg.srgb}!
 
 # if unset, will reverse foreground and background
-#highlight = #839496
+highlight = !!COL!{br_black.srgb}!
 
 # colors from color0 to color254 can be set
 color0 = !!COL!{black.srgb}!

--- a/utils/templates/termite.config.template
+++ b/utils/templates/termite.config.template
@@ -1,0 +1,32 @@
+[colors]
+# !!COL!{name}! colorscheme for Termite
+
+# 20% background transparency (requires a compositor)
+#background = rgba(63, 63, 63, 0.8)
+
+foreground = !!COL!{fg.srgb}!
+foreground_bold = !!COL!{br_white.srgb}!
+#foreground_dim = #888888
+background = !!COL!{bg.srgb}!
+cursor = !!COL!{fg.srgb}!
+
+# if unset, will reverse foreground and background
+#highlight = #839496
+
+# colors from color0 to color254 can be set
+color0 = !!COL!{black.srgb}!
+color1 = !!COL!{red.srgb}!
+color2 = !!COL!{green.srgb}!
+color3 = !!COL!{yellow.srgb}!
+color4 = !!COL!{blue.srgb}!
+color5 = !!COL!{magenta.srgb}!
+color6 = !!COL!{cyan.srgb}!
+color7 = !!COL!{white.srgb}!
+color8 = !!COL!{br_black.srgb}!
+color9 = !!COL!{br_red.srgb}!
+color10 = !!COL!{br_green.srgb}!
+color11 = !!COL!{br_yellow.srgb}!
+color12 = !!COL!{br_blue.srgb}!
+color13 = !!COL!{br_magenta.srgb}!
+color14 = !!COL!{br_cyan.srgb}!
+color15 = !!COL!{br_white.srgb}!


### PR DESCRIPTION
I have started using [Termite](https://github.com/thestinger/termite), an awesome little terminal. It's VTE based, so that means good accessibility features, neat [keybindings](https://github.com/thestinger/termite#keybindings) and [Wayland native](https://github.com/swaywm/sway/wiki#which-terminal-emulator-can-i-use) support.

Most of what you'd expect is there and it ended up being a good alternative to urxvt-unicode (which has to run through XWayland).