### PR TITLE
Wofi color scheme

### DIFF
--- a/utils/templates/wofi.css.template
+++ b/utils/templates/wofi.css.template
@@ -1,0 +1,60 @@
+/**
+ * !!COL!{name}! variant Wofi Color theme
+ **/
+
+
+window {
+    margin: 1px;
+    border: 1px solid !!COL!{fg.srgb}!;
+    background-color: !!COL!{bg.srgb}!;
+}
+
+#input {
+    margin: 1px;
+    border: 2px dashed !!COL!{br_green.srgb}!;
+    border-top-color: !!COL!{bg.srgb}!;
+    border-left-color: !!COL!{bg.srgb}!;
+    border-right-color: !!COL!{bg.srgb}!;
+    border-bottom-color: !!COL!{br_green.srgb}!;
+    background-color: !!COL!{bg.srgb}!;
+    color: !!COL!{fg.srgb}!;
+    font: 14px DejaVu Sans Mono;
+}
+
+#inner-box {
+    margin: 1px;
+    border: 2px none !!COL!{bg.srgb}!;
+    background-color: !!COL!{bg.srgb}!;
+}
+
+#outer-box {
+    margin: 1px;
+    border: 2px none !!COL!{bg.srgb}!;
+    background-color: !!COL!{bg.srgb}!;
+}
+
+#scroll {
+    margin: 1px;
+    border: 2px solid !!COL!{bg.srgb}!;
+    background-color: !!COL!{bg.srgb}!;
+    color: !!COL!{fg.srgb}!;
+}
+
+#text {
+    margin: 1px;
+    border: 1px none !!COL!{bg.srgb}!;
+    font: 14px DejaVu Sans Mono;
+}
+
+#selected {
+    margin: 0px;
+    border: 2px none !!COL!{bg_bright_2.srgb}!;
+    background-color: !!COL!{bg_bright_2.srgb}!;
+    color: !!COL!{fg.srgb}!;
+}
+
+#entry {
+    margin: 1px;
+    border: 1px none !!COL!{bg.srgb}!;
+    background-color: !!COL!{bg.srgb}!;
+}

--- a/wofi/README.md
+++ b/wofi/README.md
@@ -1,0 +1,5 @@
+# Selenized color palette for Wofi
+
+A [Wofi](https://hg.sr.ht/~scoopta/wofi) color scheme. Wofi is a Wayland native replacement for
+
+Included is a basic config, the Wofi site has some [styling information](https://cloudninja.pw/docs/wofi.html). The [GTK+ CSS Supported properties](https://developer.gnome.org/gtk3/stable/chap-css-properties.html) is also helpful for knowing what to set.

--- a/wofi/README.md
+++ b/wofi/README.md
@@ -1,5 +1,9 @@
 # Selenized color palette for Wofi
 
-A [Wofi](https://hg.sr.ht/~scoopta/wofi) color scheme. Wofi is a Wayland native replacement for
+A [Wofi](https://hg.sr.ht/~scoopta/wofi) color scheme. Wofi is a Wayland native replacement for Rofi.
 
 Included is a basic config, the Wofi site has some [styling information](https://cloudninja.pw/docs/wofi.html). The [GTK+ CSS Supported properties](https://developer.gnome.org/gtk3/stable/chap-css-properties.html) is also helpful for knowing what to set.
+
+1.  The config file which defaults to `$XDG_CONFIG_HOME/wofi/config`.
+
+2.  The CSS file which defaults to `$XDG_CONFIG_HOME/wofi/style.css`.

--- a/wofi/config
+++ b/wofi/config
@@ -1,0 +1,15 @@
+# A list of modes can be found in wofi(7)
+show=drun
+
+# If true allows image escape sequences to be processed and rendered,
+allow_images=true
+
+# Specifies  the  CSS  file  to use as the stylesheet
+stylesheet=selenized-dark.css
+
+# Specifies the term to use when running a program in a terminal.
+term=alacritty
+
+# See wofi(7) for more information, default is center.
+location=top_left
+

--- a/wofi/selenized-black.css
+++ b/wofi/selenized-black.css
@@ -1,0 +1,60 @@
+/**
+ * Selenized black variant Wofi Color theme
+ **/
+
+
+window {
+    margin: 1px;
+    border: 1px solid #b9b9b9;
+    background-color: #181818;
+}
+
+#input {
+    margin: 1px;
+    border: 2px dashed #83c746;
+    border-top-color: #181818;
+    border-left-color: #181818;
+    border-right-color: #181818;
+    border-bottom-color: #83c746;
+    background-color: #181818;
+    color: #b9b9b9;
+    font: 14px DejaVu Sans Mono;
+}
+
+#inner-box {
+    margin: 1px;
+    border: 2px none #181818;
+    background-color: #181818;
+}
+
+#outer-box {
+    margin: 1px;
+    border: 2px none #181818;
+    background-color: #181818;
+}
+
+#scroll {
+    margin: 1px;
+    border: 2px solid #181818;
+    background-color: #181818;
+    color: #b9b9b9;
+}
+
+#text {
+    margin: 1px;
+    border: 1px none #181818;
+    font: 14px DejaVu Sans Mono;
+}
+
+#selected {
+    margin: 0px;
+    border: 2px none #3b3b3b;
+    background-color: #3b3b3b;
+    color: #b9b9b9;
+}
+
+#entry {
+    margin: 1px;
+    border: 1px none #181818;
+    background-color: #181818;
+}

--- a/wofi/selenized-dark.css
+++ b/wofi/selenized-dark.css
@@ -1,0 +1,60 @@
+/**
+ * Selenized dark variant Wofi Color theme
+ **/
+
+
+window {
+    margin: 1px;
+    border: 1px solid #adbcbc;
+    background-color: #103c48;
+}
+
+#input {
+    margin: 1px;
+    border: 2px dashed #84c747;
+    border-top-color: #103c48;
+    border-left-color: #103c48;
+    border-right-color: #103c48;
+    border-bottom-color: #84c747;
+    background-color: #103c48;
+    color: #adbcbc;
+    font: 14px DejaVu Sans Mono;
+}
+
+#inner-box {
+    margin: 1px;
+    border: 2px none #103c48;
+    background-color: #103c48;
+}
+
+#outer-box {
+    margin: 1px;
+    border: 2px none #103c48;
+    background-color: #103c48;
+}
+
+#scroll {
+    margin: 1px;
+    border: 2px solid #103c48;
+    background-color: #103c48;
+    color: #adbcbc;
+}
+
+#text {
+    margin: 1px;
+    border: 1px none #103c48;
+    font: 14px DejaVu Sans Mono;
+}
+
+#selected {
+    margin: 0px;
+    border: 2px none #325b66;
+    background-color: #325b66;
+    color: #adbcbc;
+}
+
+#entry {
+    margin: 1px;
+    border: 1px none #103c48;
+    background-color: #103c48;
+}

--- a/wofi/selenized-light.css
+++ b/wofi/selenized-light.css
@@ -1,0 +1,60 @@
+/**
+ * Selenized light variant Wofi Color theme
+ **/
+
+
+window {
+    margin: 1px;
+    border: 1px solid #53676d;
+    background-color: #fbf3db;
+}
+
+#input {
+    margin: 1px;
+    border: 2px dashed #428b00;
+    border-top-color: #fbf3db;
+    border-left-color: #fbf3db;
+    border-right-color: #fbf3db;
+    border-bottom-color: #428b00;
+    background-color: #fbf3db;
+    color: #53676d;
+    font: 14px DejaVu Sans Mono;
+}
+
+#inner-box {
+    margin: 1px;
+    border: 2px none #fbf3db;
+    background-color: #fbf3db;
+}
+
+#outer-box {
+    margin: 1px;
+    border: 2px none #fbf3db;
+    background-color: #fbf3db;
+}
+
+#scroll {
+    margin: 1px;
+    border: 2px solid #fbf3db;
+    background-color: #fbf3db;
+    color: #53676d;
+}
+
+#text {
+    margin: 1px;
+    border: 1px none #fbf3db;
+    font: 14px DejaVu Sans Mono;
+}
+
+#selected {
+    margin: 0px;
+    border: 2px none #cfcebe;
+    background-color: #cfcebe;
+    color: #53676d;
+}
+
+#entry {
+    margin: 1px;
+    border: 1px none #fbf3db;
+    background-color: #fbf3db;
+}

--- a/wofi/selenized-white.css
+++ b/wofi/selenized-white.css
@@ -1,0 +1,60 @@
+/**
+ * Selenized white variant Wofi Color theme
+ **/
+
+
+window {
+    margin: 1px;
+    border: 1px solid #474747;
+    background-color: #ffffff;
+}
+
+#input {
+    margin: 1px;
+    border: 2px dashed #008400;
+    border-top-color: #ffffff;
+    border-left-color: #ffffff;
+    border-right-color: #ffffff;
+    border-bottom-color: #008400;
+    background-color: #ffffff;
+    color: #474747;
+    font: 14px DejaVu Sans Mono;
+}
+
+#inner-box {
+    margin: 1px;
+    border: 2px none #ffffff;
+    background-color: #ffffff;
+}
+
+#outer-box {
+    margin: 1px;
+    border: 2px none #ffffff;
+    background-color: #ffffff;
+}
+
+#scroll {
+    margin: 1px;
+    border: 2px solid #ffffff;
+    background-color: #ffffff;
+    color: #474747;
+}
+
+#text {
+    margin: 1px;
+    border: 1px none #ffffff;
+    font: 14px DejaVu Sans Mono;
+}
+
+#selected {
+    margin: 0px;
+    border: 2px none #cdcdcd;
+    background-color: #cdcdcd;
+    color: #474747;
+}
+
+#entry {
+    margin: 1px;
+    border: 1px none #ffffff;
+    background-color: #ffffff;
+}


### PR DESCRIPTION
I decided now that I use [Sway](https://swaywm.org) more to include my [Wofi](https://hg.sr.ht/~scoopta/wofi) color schemes. Wofi is a Wayland native replacement for Rofi. I aimed to make it look like the Rofi configs in https://github.com/jan-warchol/selenized/pull/48

I've included a basic config too as this took me a while to get like I wanted. They have a site which has some [styling information](https://cloudninja.pw/docs/wofi.html).

The [GTK+ CSS Supported properties](https://developer.gnome.org/gtk3/stable/chap-css-properties.html) is also helpful for knowing what to set.

![wofi](https://user-images.githubusercontent.com/48640805/76957469-c4795a00-690d-11ea-8371-fcfb65740890.png)
