### PR TITLE
add kitty tabbar colors and rebuild conf files

### DIFF
--- a/terminals/kitty/kitty-selenized-black.conf
+++ b/terminals/kitty/kitty-selenized-black.conf
@@ -1,9 +1,10 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
+# Selenized black color scheme for Kitty
+
 #: Color scheme {{{
 
 #: The foreground and background colors
-Selenized black color scheme for Kitty
 foreground #b9b9b9
 background #181818
 
@@ -40,6 +41,12 @@ selection_foreground none
 #: The background for text selected with the mouse.
 selection_background #3b3b3b
 
+#: Tab bar colors
+active_tab_foreground   #dedede
+active_tab_background   #3b3b3b
+inactive_tab_foreground #777777
+inactive_tab_background #181818
+tab_bar_background      #181818
 
 #: The 16 terminal colors. There are 8 basic colors, each color has a
 #: dull and bright version. You can also set the remaining colors from

--- a/terminals/kitty/kitty-selenized-dark.conf
+++ b/terminals/kitty/kitty-selenized-dark.conf
@@ -1,9 +1,10 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
+# Selenized dark color scheme for Kitty
+
 #: Color scheme {{{
 
 #: The foreground and background colors
-Selenized dark color scheme for Kitty
 foreground #adbcbc
 background #103c48
 
@@ -38,16 +39,22 @@ dim_opacity 0.625
 selection_foreground none
 
 #: The background for text selected with the mouse.
-selection_background #2d5b69
+selection_background #325b66
 
+#: Tab bar colors
+active_tab_foreground   #cad8d9
+active_tab_background   #325b66
+inactive_tab_foreground #72898f
+inactive_tab_background #103c48
+tab_bar_background      #103c48
 
 #: The 16 terminal colors. There are 8 basic colors, each color has a
 #: dull and bright version. You can also set the remaining colors from
 #: the 256 color table as color16 to color255.
 
 #: black
-color0 #184956
-color8 #2d5b69
+color0 #174956
+color8 #325b66
 
 #: red
 color1 #fa5750

--- a/terminals/kitty/kitty-selenized-light.conf
+++ b/terminals/kitty/kitty-selenized-light.conf
@@ -1,9 +1,10 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
+# Selenized light color scheme for Kitty
+
 #: Color scheme {{{
 
 #: The foreground and background colors
-Selenized light color scheme for Kitty
 foreground #53676d
 background #fbf3db
 
@@ -38,16 +39,22 @@ dim_opacity 0.625
 selection_foreground none
 
 #: The background for text selected with the mouse.
-selection_background #d5cdb6
+selection_background #cfcebe
 
+#: Tab bar colors
+active_tab_foreground   #3a4d53
+active_tab_background   #cfcebe
+inactive_tab_foreground #909995
+inactive_tab_background #fbf3db
+tab_bar_background      #fbf3db
 
 #: The 16 terminal colors. There are 8 basic colors, each color has a
 #: dull and bright version. You can also set the remaining colors from
 #: the 256 color table as color16 to color255.
 
 #: black
-color0 #ece3cc
-color8 #d5cdb6
+color0 #e9e4d0
+color8 #cfcebe
 
 #: red
 color1 #d2212d

--- a/terminals/kitty/kitty-selenized-white.conf
+++ b/terminals/kitty/kitty-selenized-white.conf
@@ -1,9 +1,10 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
+# Selenized white color scheme for Kitty
+
 #: Color scheme {{{
 
 #: The foreground and background colors
-Selenized white color scheme for Kitty
 foreground #474747
 background #ffffff
 
@@ -40,6 +41,12 @@ selection_foreground none
 #: The background for text selected with the mouse.
 selection_background #cdcdcd
 
+#: Tab bar colors
+active_tab_foreground   #282828
+active_tab_background   #cdcdcd
+inactive_tab_foreground #878787
+inactive_tab_background #ffffff
+tab_bar_background      #ffffff
 
 #: The 16 terminal colors. There are 8 basic colors, each color has a
 #: dull and bright version. You can also set the remaining colors from

--- a/utils/templates/kitty.conf.template
+++ b/utils/templates/kitty.conf.template
@@ -1,9 +1,10 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
+# !!COL!{name}! color scheme for Kitty
+
 #: Color scheme {{{
 
 #: The foreground and background colors
-!!COL!{name}! color scheme for Kitty
 foreground !!COL!{fg_0.srgb}!
 background !!COL!{bg_0.srgb}!
 
@@ -40,6 +41,12 @@ selection_foreground none
 #: The background for text selected with the mouse.
 selection_background !!COL!{bg_2.srgb}!
 
+#: Tab bar colors
+active_tab_foreground   !!COL!{fg_1.srgb}!
+active_tab_background   !!COL!{bg_2.srgb}!
+inactive_tab_foreground !!COL!{dim_0.srgb}!
+inactive_tab_background !!COL!{bg_0.srgb}!
+tab_bar_background      !!COL!{bg_0.srgb}!
 
 #: The 16 terminal colors. There are 8 basic colors, each color has a
 #: dull and bright version. You can also set the remaining colors from


### PR DESCRIPTION
The tabbar colors were missing from the kitty templates. This PR adds them to the template and updates the theme files. Here's the result for all colorschemes:

<img width="1536" alt="image" src="https://user-images.githubusercontent.com/1460122/78542811-651db400-7800-11ea-9627-14026507c197.png">
