### PR TITLE
Fix urxvt colors to actually work

### DIFF
--- a/terminals/urxvt/selenized-black.xdefaults
+++ b/terminals/urxvt/selenized-black.xdefaults
@@ -1,25 +1,55 @@
-! Selenized black color palette for urxvt.
+!---------------------------------------------------------------------------
+! Selenized black color palette for urxvt and X Window System
+!
+#define    bg_0        #181818
+#define    bg_1        #252525
+#define    bg_2        #3b3b3b
+#define    dim_0       #777777
+#define    fg_0        #b9b9b9
+#define    fg_1        #dedede
 
-urxvt.background:  #181818
-urxvt.foreground:  #b9b9b9
+#define    red         #ed4a46
+#define    green       #70b433
+#define    yellow      #dbb32d
+#define    blue        #368aeb
+#define    magenta     #eb6eb7
+#define    cyan        #3fc5b7
+#define    orange      #e67f43
+#define    violet      #a580e2
+
+#define    br_red      #ff5e56
+#define    br_green    #83c746
+#define    br_yellow   #efc541
+#define    br_blue     #4f9cfe
+#define    br_magenta  #ff81ca
+#define    br_cyan     #56d8c9
+#define    br_orange   #fa9153
+#define    br_violet   #b891f5
+
+*background:              bg_0
+*foreground:              fg_0
+*fading:                  40
+*fadeColor:               bg_0
+*cursorColor:             fg_1
+*pointerColorBackground:  bg_2
+*pointerColorForeground:  fg_1
 
 ! normal colors: "black", red, green, yellow, blue, magenta, cyan, "white"
-urxvt.color0:      #252525
-urxvt.color1:      #ed4a46
-urxvt.color2:      #70b433
-urxvt.color3:      #dbb32d
-urxvt.color4:      #368aeb
-urxvt.color5:      #eb6eb7
-urxvt.color6:      #3fc5b7
-urxvt.color7:      #777777
+*color0:     bg_1
+*color1:     red
+*color2:     green
+*color3:     yellow
+*color4:     blue
+*color5:     magenta
+*color6:     cyan
+*color7:     dim_0
 
 ! bright/bold versions of colors (in the same order)
-urxvt.color8:      #3b3b3b
-urxvt.color9:      #ff5e56
-urxvt.color10:     #83c746
-urxvt.color11:     #efc541
-urxvt.color12:     #4f9cfe
-urxvt.color13:     #ff81ca
-urxvt.color14:     #56d8c9
-urxvt.color15:     #dedede
-
+*color8:     bg_2
+*color9:     br_red
+*color10:    br_green
+*color11:    br_yellow
+*color12:    br_blue
+*color13:    br_magenta
+*color14:    br_cyan
+*color15:    fg_1

--- a/terminals/urxvt/selenized-dark.xdefaults
+++ b/terminals/urxvt/selenized-dark.xdefaults
@@ -1,25 +1,55 @@
-! Selenized dark color palette for urxvt.
+!---------------------------------------------------------------------------
+! Selenized dark color palette for urxvt and X Window System
+!
+#define    bg_0        #103c48
+#define    bg_1        #174956
+#define    bg_2        #325b66
+#define    dim_0       #72898f
+#define    fg_0        #adbcbc
+#define    fg_1        #cad8d9
 
-urxvt.background:  #103c48
-urxvt.foreground:  #adbcbc
+#define    red         #fa5750
+#define    green       #75b938
+#define    yellow      #dbb32d
+#define    blue        #4695f7
+#define    magenta     #f275be
+#define    cyan        #41c7b9
+#define    orange      #ed8649
+#define    violet      #af88eb
+
+#define    br_red      #ff665c
+#define    br_green    #84c747
+#define    br_yellow   #ebc13d
+#define    br_blue     #58a3ff
+#define    br_magenta  #ff84cd
+#define    br_cyan     #53d6c7
+#define    br_orange   #fd9456
+#define    br_violet   #bd96fa
+
+*background:              bg_0
+*foreground:              fg_0
+*fading:                  40
+*fadeColor:               bg_0
+*cursorColor:             fg_1
+*pointerColorBackground:  bg_2
+*pointerColorForeground:  fg_1
 
 ! normal colors: "black", red, green, yellow, blue, magenta, cyan, "white"
-urxvt.color0:      #184956
-urxvt.color1:      #fa5750
-urxvt.color2:      #75b938
-urxvt.color3:      #dbb32d
-urxvt.color4:      #4695f7
-urxvt.color5:      #f275be
-urxvt.color6:      #41c7b9
-urxvt.color7:      #72898f
+*color0:     bg_1
+*color1:     red
+*color2:     green
+*color3:     yellow
+*color4:     blue
+*color5:     magenta
+*color6:     cyan
+*color7:     dim_0
 
 ! bright/bold versions of colors (in the same order)
-urxvt.color8:      #2d5b69
-urxvt.color9:      #ff665c
-urxvt.color10:     #84c747
-urxvt.color11:     #ebc13d
-urxvt.color12:     #58a3ff
-urxvt.color13:     #ff84cd
-urxvt.color14:     #53d6c7
-urxvt.color15:     #cad8d9
-
+*color8:     bg_2
+*color9:     br_red
+*color10:    br_green
+*color11:    br_yellow
+*color12:    br_blue
+*color13:    br_magenta
+*color14:    br_cyan
+*color15:    fg_1

--- a/terminals/urxvt/selenized-light.xdefaults
+++ b/terminals/urxvt/selenized-light.xdefaults
@@ -1,25 +1,55 @@
-! Selenized light color palette for urxvt.
+!---------------------------------------------------------------------------
+! Selenized light color palette for urxvt and X Window System
+!
+#define    bg_0        #fbf3db
+#define    bg_1        #e9e4d0
+#define    bg_2        #cfcebe
+#define    dim_0       #909995
+#define    fg_0        #53676d
+#define    fg_1        #3a4d53
 
-urxvt.background:  #fbf3db
-urxvt.foreground:  #53676d
+#define    red         #d2212d
+#define    green       #489100
+#define    yellow      #ad8900
+#define    blue        #0072d4
+#define    magenta     #ca4898
+#define    cyan        #009c8f
+#define    orange      #c25d1e
+#define    violet      #8762c6
+
+#define    br_red      #cc1729
+#define    br_green    #428b00
+#define    br_yellow   #a78300
+#define    br_blue     #006dce
+#define    br_magenta  #c44392
+#define    br_cyan     #00978a
+#define    br_orange   #bc5819
+#define    br_violet   #825dc0
+
+*background:              bg_0
+*foreground:              fg_0
+*fading:                  40
+*fadeColor:               bg_0
+*cursorColor:             fg_1
+*pointerColorBackground:  bg_2
+*pointerColorForeground:  fg_1
 
 ! normal colors: "black", red, green, yellow, blue, magenta, cyan, "white"
-urxvt.color0:      #ece3cc
-urxvt.color1:      #d2212d
-urxvt.color2:      #489100
-urxvt.color3:      #ad8900
-urxvt.color4:      #0072d4
-urxvt.color5:      #ca4898
-urxvt.color6:      #009c8f
-urxvt.color7:      #909995
+*color0:     bg_1
+*color1:     red
+*color2:     green
+*color3:     yellow
+*color4:     blue
+*color5:     magenta
+*color6:     cyan
+*color7:     dim_0
 
 ! bright/bold versions of colors (in the same order)
-urxvt.color8:      #d5cdb6
-urxvt.color9:      #cc1729
-urxvt.color10:     #428b00
-urxvt.color11:     #a78300
-urxvt.color12:     #006dce
-urxvt.color13:     #c44392
-urxvt.color14:     #00978a
-urxvt.color15:     #3a4d53
-
+*color8:     bg_2
+*color9:     br_red
+*color10:    br_green
+*color11:    br_yellow
+*color12:    br_blue
+*color13:    br_magenta
+*color14:    br_cyan
+*color15:    fg_1

--- a/terminals/urxvt/selenized-white.xdefaults
+++ b/terminals/urxvt/selenized-white.xdefaults
@@ -1,25 +1,55 @@
-! Selenized white color palette for urxvt.
+!---------------------------------------------------------------------------
+! Selenized white color palette for urxvt and X Window System
+!
+#define    bg_0        #ffffff
+#define    bg_1        #ebebeb
+#define    bg_2        #cdcdcd
+#define    dim_0       #878787
+#define    fg_0        #474747
+#define    fg_1        #282828
 
-urxvt.background:  #ffffff
-urxvt.foreground:  #474747
+#define    red         #d6000c
+#define    green       #1d9700
+#define    yellow      #c49700
+#define    blue        #0064e4
+#define    magenta     #dd0f9d
+#define    cyan        #00ad9c
+#define    orange      #d04a00
+#define    violet      #7f51d6
+
+#define    br_red      #bf0000
+#define    br_green    #008400
+#define    br_yellow   #af8500
+#define    br_blue     #0054cf
+#define    br_magenta  #c7008b
+#define    br_cyan     #009a8a
+#define    br_orange   #ba3700
+#define    br_violet   #6b40c3
+
+*background:              bg_0
+*foreground:              fg_0
+*fading:                  40
+*fadeColor:               bg_0
+*cursorColor:             fg_1
+*pointerColorBackground:  bg_2
+*pointerColorForeground:  fg_1
 
 ! normal colors: "black", red, green, yellow, blue, magenta, cyan, "white"
-urxvt.color0:      #ebebeb
-urxvt.color1:      #d6000c
-urxvt.color2:      #1d9700
-urxvt.color3:      #c49700
-urxvt.color4:      #0064e4
-urxvt.color5:      #dd0f9d
-urxvt.color6:      #00ad9c
-urxvt.color7:      #878787
+*color0:     bg_1
+*color1:     red
+*color2:     green
+*color3:     yellow
+*color4:     blue
+*color5:     magenta
+*color6:     cyan
+*color7:     dim_0
 
 ! bright/bold versions of colors (in the same order)
-urxvt.color8:      #cdcdcd
-urxvt.color9:      #bf0000
-urxvt.color10:     #008400
-urxvt.color11:     #af8500
-urxvt.color12:     #0054cf
-urxvt.color13:     #c7008b
-urxvt.color14:     #009a8a
-urxvt.color15:     #282828
-
+*color8:     bg_2
+*color9:     br_red
+*color10:    br_green
+*color11:    br_yellow
+*color12:    br_blue
+*color13:    br_magenta
+*color14:    br_cyan
+*color15:    fg_1

--- a/utils/templates/urxvt.xdefaults.template
+++ b/utils/templates/urxvt.xdefaults.template
@@ -1,25 +1,55 @@
-! !!COL!{name}! color palette for urxvt.
+!---------------------------------------------------------------------------
+! !!COL!{name}! color palette for urxvt and X Window System
+!
+#define    bg_0        !!COL!{bg_0.srgb}!
+#define    bg_1        !!COL!{bg_1.srgb}!
+#define    bg_2        !!COL!{bg_2.srgb}!
+#define    dim_0       !!COL!{dim_0.srgb}!
+#define    fg_0        !!COL!{fg_0.srgb}!
+#define    fg_1        !!COL!{fg_1.srgb}!
 
-urxvt.background:  !!COL!{bg_0.srgb}!
-urxvt.foreground:  !!COL!{fg_0.srgb}!
+#define    red         !!COL!{red.srgb}!
+#define    green       !!COL!{green.srgb}!
+#define    yellow      !!COL!{yellow.srgb}!
+#define    blue        !!COL!{blue.srgb}!
+#define    magenta     !!COL!{magenta.srgb}!
+#define    cyan        !!COL!{cyan.srgb}!
+#define    orange      !!COL!{orange.srgb}!
+#define    violet      !!COL!{violet.srgb}!
+
+#define    br_red      !!COL!{br_red.srgb}!
+#define    br_green    !!COL!{br_green.srgb}!
+#define    br_yellow   !!COL!{br_yellow.srgb}!
+#define    br_blue     !!COL!{br_blue.srgb}!
+#define    br_magenta  !!COL!{br_magenta.srgb}!
+#define    br_cyan     !!COL!{br_cyan.srgb}!
+#define    br_orange   !!COL!{br_orange.srgb}!
+#define    br_violet   !!COL!{br_violet.srgb}!
+
+*background:              bg_0
+*foreground:              fg_0
+*fading:                  40
+*fadeColor:               bg_0
+*cursorColor:             fg_1
+*pointerColorBackground:  bg_2
+*pointerColorForeground:  fg_1
 
 ! normal colors: "black", red, green, yellow, blue, magenta, cyan, "white"
-urxvt.color0:      !!COL!{bg_1.srgb}!
-urxvt.color1:      !!COL!{red.srgb}!
-urxvt.color2:      !!COL!{green.srgb}!
-urxvt.color3:      !!COL!{yellow.srgb}!
-urxvt.color4:      !!COL!{blue.srgb}!
-urxvt.color5:      !!COL!{magenta.srgb}!
-urxvt.color6:      !!COL!{cyan.srgb}!
-urxvt.color7:      !!COL!{dim_0.srgb}!
+*color0:     bg_1
+*color1:     red
+*color2:     green
+*color3:     yellow
+*color4:     blue
+*color5:     magenta
+*color6:     cyan
+*color7:     dim_0
 
 ! bright/bold versions of colors (in the same order)
-urxvt.color8:      !!COL!{bg_2.srgb}!
-urxvt.color9:      !!COL!{br_red.srgb}!
-urxvt.color10:     !!COL!{br_green.srgb}!
-urxvt.color11:     !!COL!{br_yellow.srgb}!
-urxvt.color12:     !!COL!{br_blue.srgb}!
-urxvt.color13:     !!COL!{br_magenta.srgb}!
-urxvt.color14:     !!COL!{br_cyan.srgb}!
-urxvt.color15:     !!COL!{fg_1.srgb}!
-
+*color8:     bg_2
+*color9:     br_red
+*color10:    br_green
+*color11:    br_yellow
+*color12:    br_blue
+*color13:    br_magenta
+*color14:    br_cyan
+*color15:    fg_1


### PR DESCRIPTION
I was using the urxvt colors in a Debian virtual machine with lightdm and discovered they were not working when I would open a new terminal.

I don't think we should be setting `urxvt.` This will mean the colors should work with another terminal that isn't urxvt.