### PR TITLE
fix(gnome-terminal): run against GNOME Terminal 3.42.2, Fedora 35

### DIFF
--- a/terminals/gnome-terminal/README.mkd
+++ b/terminals/gnome-terminal/README.mkd
@@ -12,7 +12,7 @@ Clone this repository, run interactive installation script and follow the
 instructions:
 
     git clone https://github.com/janek-warchol/selenized
-    ./selenized/gnome-terminal/install.sh
+    ./selenized/terminals/gnome-terminal/install.sh
 
 You can also run one of the `set_XXXX.sh` scripts to directly set the desired
 theme to the active gnome-terminal profile.
@@ -21,7 +21,7 @@ theme to the active gnome-terminal profile.
 your Gnome version) to be able to run these scripts.  This should be as easy as
 running `sudo apt-get install <package>`. 
 
-**Warning:** the colors in the target profile will be premanently overwritten -
+**Warning:** the colors in the target profile will be permanently overwritten -
 there is no undo.  Consider creating a new profile before installing Selenized.
 
 

--- a/terminals/gnome-terminal/src/profiles.sh
+++ b/terminals/gnome-terminal/src/profiles.sh
@@ -50,7 +50,7 @@ get_profile_name() {
     then profile_name="$(dconf read $dconfdir/$1/visible-name | sed s/^\'// | \
         sed s/\'$//)"
   else
-    profile_name=$(gconftool-2 -g $gconfdir/$1/visible_name)
+    profile_name=$(gconftool-2 -g "$gconfdir/$1/visible_name")
   fi
   [[ -z $profile_name ]] && die "$1 (No name)" 3
   echo $profile_name

--- a/terminals/gnome-terminal/src/tools.sh
+++ b/terminals/gnome-terminal/src/tools.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
+# gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
+gnomeVersion="$(gnome-terminal --version | awk '{print $4}')"
+# example output on Fedora 35
+# GNOME Terminal 3.42.2 using VTE 0.66.2 +BIDI +GNUTLS +ICU +SYSTEMD
+echo "gnome-terminal-version=${gnomeVersion}"
 
 # newGnome=1 if the gnome-terminal version >= 3.8
 if [[ ("$(echo "$gnomeVersion" | cut -d"." -f1)" = "3" && \


### PR DESCRIPTION
In order to get it to work w/ Fedora 25 / Gnome 3.42 I had to quote CLI argument to `gconftool-2` and change the way the gnome version was obtained.

I also fixed outdated reference in readme and one typo.